### PR TITLE
feat: パネルの定型文タブにフィルタリング機能を追加

### DIFF
--- a/public/iframe.html
+++ b/public/iframe.html
@@ -127,11 +127,11 @@
     <div class="tab-content">
       <!-- 定型文タブ -->
       <div class="tab-pane fade show active pt-2" id="templates">
-        <div class="d-flex">
+        <div class="d-flex justify-content-between align-items-center">
           <button id="templates-left-arrow" type="button" class="btn p-0 btn-arrow">
             <i class="bi bi-caret-left-fill text-custom" style="font-size: 20px; line-height: 1;"></i>
           </button>
-          <div class="d-flex overflow-x-auto btn-container" role="group" style="gap: 0.5rem;">
+          <div class="d-flex w-100 overflow-x-auto btn-container gap-1" role="group">
             <button type="button" class="btn text-white-50 flex-shrink-0 p-2 template-item"
               data-text="お世話になっております。&#10;&#10;以下の件について確認させていただきたく、ご連絡いたしました。">
               <small class="text-custom d-block">お世話になっております...</small>

--- a/src/content/templates.ts
+++ b/src/content/templates.ts
@@ -1,0 +1,11 @@
+/** テンプレートアイテムのクリックリスナーを設定 */
+export function setupTemplateItemListeners(iframeDoc: Document): void {
+  const templateItems = iframeDoc.querySelectorAll<HTMLElement>('.template-item');
+
+  templateItems.forEach(item => {
+    item.addEventListener('click', () => {
+      const text = item.getAttribute('data-text') || '';
+      window.parent.postMessage({ type: 'insertText', text: text }, '*');
+    });
+  });
+}


### PR DESCRIPTION
入力要素で `/` コマンドで表示されるパネル内の定型文タブに，入力内容に基づくフィルタリング機能を追加

詳細
`/` コマンドを実行した後，スラッシュに続けて入力された文字列が検索クエリとして機能し，定型文タブに表示される定型文リストをリアルタイムで絞り込む