### PR TITLE
fix: 絵文字フィルタリング機能の修正

### DIFF
--- a/public/iframe.html
+++ b/public/iframe.html
@@ -79,7 +79,7 @@
 
         <!-- 絵文字の名前 -->
         <div class="" id="emojis-name-container">
-          <div id="emoji-name" class="text-custom d-none fs-6 ps-3">絵文字名</div>
+          <div id="emoji-name" class="text-white d-none fs-6 ps-3">絵文字名</div>
         </div>
       </div>
 
@@ -195,19 +195,24 @@
       <!-- 絵文字タブ -->
       <div class="tab-pane fade pb-2 px-2" id="emojis">
         <div class="d-flex overflow-x-auto btn-container gap-1" role="group">
-          <button type="button" class="btn text-white-50 flex-shrink-0 p-1 emoji-item" data-emoji="😀" title="スマイル" data-text="スマイル">
+          <button type="button" class="btn text-white-50 flex-shrink-0 p-1 emoji-item" data-emoji="😀"
+            title="スマイル - smile" data-text="スマイル" data-text-en="smile">
             <span class="text-custom d-block">😀</span>
           </button>
-          <button type="button" class="btn text-white-50 flex-shrink-0 p-1 emoji-item" data-emoji="😂" title="笑い" data-text="笑い">
+          <button type="button" class="btn text-white-50 flex-shrink-0 p-1 emoji-item" data-emoji="😂"
+            title="笑い - laugh" data-text="笑い" data-text-en="laugh">
             <span class="text-custom d-block">😂</span>
           </button>
-          <button type="button" class="btn text-white-50 flex-shrink-0 p-1 emoji-item" data-emoji="😍" title="ハート目" data-text="ハート目">
+          <button type="button" class="btn text-white-50 flex-shrink-0 p-1 emoji-item" data-emoji="😍"
+            title="ハート目 - heart_eyes" data-text="ハート目" data-text-en="heart_eyes">
             <span class="text-custom d-block">😍</span>
           </button>
-          <button type="button" class="btn text-white-50 flex-shrink-0 p-1 emoji-item" data-emoji="👍" title="いいね" data-text="いいね">
+          <button type="button" class="btn text-white-50 flex-shrink-0 p-1 emoji-item" data-emoji="👍"
+            title="いいね - thumbs_up" data-text="いいね" data-text-en="thumbs_up">
             <span class="text-custom d-block">👍</span>
           </button>
-          <button type="button" class="btn text-white-50 flex-shrink-0 p-1 emoji-item" data-emoji="🙏" title="お願い" data-text="お願い">
+          <button type="button" class="btn text-white-50 flex-shrink-0 p-1 emoji-item" data-emoji="🙏"
+            title="お願い - pray" data-text="お願い" data-text-en="pray">
             <span class="text-custom d-block">🙏</span>
           </button>
         </div>
@@ -215,7 +220,7 @@
 
       <!-- 履歴タブ -->
       <div class="tab-pane fade pt-2" id="history">
-        <div class="mb-2 w-100 d-flex justify-content-between" id="template-chat">
+        <div class="pb-2 d-flex justify-content-between" id="template-chat">
           <button id="history-left-arrow" type="button" class="btn p-0 btn-arrow">
             <i class="bi bi-caret-left-fill text-custom" style="font-size: 20px; line-height: 1;"></i>
           </button>

--- a/src/content.ts
+++ b/src/content.ts
@@ -79,11 +79,18 @@ class ContentScript {
         this.inputPanel.getIframe().activeToolsTab();
         this.inputPanel.show(targetElement);
         this.inputPanel.getIframe().setSelectedText(selectedText);
-      } else if (text.startsWith(':') || text.endsWith(':')) {
+      } else if (text.startsWith(':') || text.includes(':')) {
         // 絵文字コマンドが入力されたとき
-        const emojiQuery = text.substring(1); // ":"以降の文字列を取得
+        const emojiQuery = () => {
+          if (text.startsWith(':')) {
+            return text.substring(1);
+          } else {
+            const lastColonIndex = text.lastIndexOf(':');
+            return text.substring(lastColonIndex + 1);
+          }
+        };
         this.inputPanel.getIframe().activeEmojisTab();
-        this.inputPanel.getIframe().filterEmojis(emojiQuery);
+        this.inputPanel.getIframe().filterEmojis(emojiQuery());
         this.inputPanel.show(targetElement);
       } else {
         this.inputPanel.hide();

--- a/src/content/utils/filtering.ts
+++ b/src/content/utils/filtering.ts
@@ -11,15 +11,15 @@ export function performFiltering(
   const matchedItems: Array<{ element: HTMLElement; startIndex: number }> = [];
 
   items.forEach(item => {
-    const text = item.getAttribute('data-text') || item.getAttribute('data-emoji') || '';
+    const text = item.getAttribute('data-text-en') || '';
+    const enText = item.getAttribute('data-text') || '';
     const displayText = item.textContent || '';
-    const lowerText = text.toLowerCase();
-    const lowerDisplayText = displayText.toLowerCase();
 
-    // data-text/data-emoji属性または表示テキストに検索文字列が含まれるかチェック
-    const textIndex = lowerText.indexOf(lowerQuery);
-    const displayIndex = lowerDisplayText.indexOf(lowerQuery);
-    const matches = textIndex !== -1 || displayIndex !== -1;
+    // data-text/data-text-en属性または表示テキストに検索文字列が含まれるかチェック
+    const textIndex = text.toLowerCase().indexOf(lowerQuery);
+    const enTextIndex = enText.toLowerCase().indexOf(lowerQuery);
+    const displayIndex = displayText.toLowerCase().indexOf(lowerQuery);
+    const matches = textIndex !== -1 || enTextIndex !== -1 || displayIndex !== -1;
 
     if (query === '' || matches) {
       item.style.display = '';


### PR DESCRIPTION
Closes #11

入力欄でコロン付きのクエリを扱う際の絵文字タブ挙動とフィルタリングを改善

変更内容:
- 入力が `ありがとう:` のようにコロンで終わる場合，絵文字タブをアクティブ化して全ての絵文字を表示するよう修正
- 入力が `ありがとう:sm` のようにコロンの後に文字列が続く場合，その文字列（例: `sm`）に部分一致する絵文字（例: `smile`）で絞り込むよう修正
- 日本語表記と英語名の両方で検索できるように対応（大文字小文字を正規化し部分一致で検索）